### PR TITLE
Fix bootstrap apply AWS profiles

### DIFF
--- a/bootstrap-apply.ts
+++ b/bootstrap-apply.ts
@@ -69,7 +69,7 @@ export class BootstrapApplyCliCommand<A, M extends CdkManager<A>> extends BaseCl
             NO_SYNTH: 'yes',
         };
         if (!noDefaultProfiles) {
-            env['AWS_PROFILE'] = this.manager.getDefaultPipelineDeploymentProfile(account);
+            env['AWS_PROFILE'] = this.manager.getDefaultBootstrapDeploymentProfile(account);
         }
 
         for (const selectedRegion of selectedRegions) {

--- a/manager.ts
+++ b/manager.ts
@@ -147,6 +147,11 @@ export class CdkManager<A> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getDefaultBootstrapDeploymentProfile(account: Account): string {
+        throw new Error('Unknown default bootstrap profile');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getDefaultPipelineDeploymentProfile(account: Account, instance?: Instance<A>): string {
         throw new Error('Unknown default deployment profile');
     }


### PR DESCRIPTION
Then, with this, will need something like:

```typescript
getDefaultBootstrapDeploymentProfile(account: Account): string {
    return `prefix-${account.name}-suffix`;
}
```
in the manager.